### PR TITLE
fix: 설정 페이지 React Hook 오류 수정 및 UserProfile 컴포넌트 리팩터링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ next-env.d.ts
 
 # CLAUDE.md
 CLAUDE.md
+
+# AutoBlogPython폴더
+AutoBlogPython

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,23 +1,44 @@
 'use client'
 
 import { useEffect } from 'react'
-import { onAuthStateChanged } from 'firebase/auth'
+import { onAuthStateChanged, updateProfile } from 'firebase/auth'
 import { auth } from '@/lib/firebase'
 import { useAuthStore } from '@/store/authStore'
+import { useHydration } from '@/hooks/useHydration'
 
 export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const hydrated = useHydration()
   const { setUser, setLoading } = useAuthStore()
 
   useEffect(() => {
-    // hydration 이후에 store 상태를 복원
-    useAuthStore.persist.rehydrate()
+    if (!hydrated) return
     
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUser(user)
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (user) {
+        // 닉네임이 없으면 이메일 앞부분으로 기본 설정
+        if (!user.displayName && user.email) {
+          try {
+            const defaultDisplayName = user.email.split('@')[0]
+            await updateProfile(user, {
+              displayName: defaultDisplayName
+            })
+            // 업데이트된 사용자 정보를 다시 가져오기
+            await user.reload()
+            setUser(auth.currentUser)
+          } catch (error) {
+            console.error('기본 닉네임 설정 오류:', error)
+            setUser(user)
+          }
+        } else {
+          setUser(user)
+        }
+      } else {
+        setUser(null)
+      }
     })
 
     return () => unsubscribe()
-  }, [setUser, setLoading])
+  }, [setUser, setLoading, hydrated])
 
   return <>{children}</>
 }

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -44,8 +44,8 @@ export default function Navbar() {
               <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-gray-600"></div>
             ) : isAuthenticated ? (
               <div className="flex items-center gap-4">
-                {/* 환영 메시지 */}
-                <div className="hidden sm:flex items-center gap-2 text-gray-700">
+                {/* 환영 메시지 - 클릭 시 사용자 정보로 이동 */}
+                <Link href="/settings" className="hidden sm:flex items-center gap-2 text-gray-700 hover:text-green-600 transition-colors cursor-pointer">
                   <User className="w-5 h-5 text-gray-600" />
                   <span className="text-sm">
                     {user?.displayName && (
@@ -62,15 +62,15 @@ export default function Navbar() {
                       <span className="font-medium">Navely</span>에 오신 것을 환영합니다!
                     </span>
                   </span>
-                </div>
+                </Link>
                 
-                {/* 모바일용 간단 표시 */}
-                <div className="sm:hidden flex items-center gap-2 text-gray-700">
+                {/* 모바일용 간단 표시 - 클릭 시 사용자 정보로 이동 */}
+                <Link href="/settings" className="sm:hidden flex items-center gap-2 text-gray-700 hover:text-green-600 transition-colors cursor-pointer">
                   <User className="w-4 h-4 text-gray-600" />
                   <span className="text-xs font-medium whitespace-nowrap">
                     {user?.displayName || user?.email?.split('@')[0] || '사용자'}님
                   </span>
-                </div>
+                </Link>
                 
                 <button 
                   onClick={handleLogout}

--- a/src/components/settings/SettingsTabs.tsx
+++ b/src/components/settings/SettingsTabs.tsx
@@ -4,14 +4,15 @@
 import { useState } from 'react'
 import GeminiSettings from './GeminiSettings'
 import NaverAccountSettings from './NaverAccountSettings'
+import UserProfile from './UserProfile'
 
 export default function SettingsTabs() {
-  const [activeTab, setActiveTab] = useState('gemini')
+  const [activeTab, setActiveTab] = useState('profile')
 
   const tabs = [
+    { id: 'profile', label: '사용자 정보' },
     { id: 'gemini', label: 'Gemini API' },
     { id: 'naver', label: '네이버 계정' },
-    { id: 'general', label: '기본 설정' },
   ]
 
   return (
@@ -33,14 +34,9 @@ export default function SettingsTabs() {
       </div>
 
       <div className="mt-6">
+        {activeTab === 'profile' && <UserProfile />}
         {activeTab === 'gemini' && <GeminiSettings />}
         {activeTab === 'naver' && <NaverAccountSettings />}
-        {activeTab === 'general' && (
-          <div className="bg-white rounded-lg shadow-sm border p-6">
-            <h3 className="text-lg font-semibold mb-4">기본 설정</h3>
-            <p className="text-gray-600">기본 설정 옵션들이 여기에 표시됩니다.</p>
-          </div>
-        )}
       </div>
     </>
   )

--- a/src/components/settings/UserProfile.tsx
+++ b/src/components/settings/UserProfile.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { updateProfile } from 'firebase/auth'
+import { auth } from '@/lib/firebase'
+import { useAuthStore } from '@/store/authStore'
+import { useHydration } from '@/hooks/useHydration'
+import { User, Mail, Calendar, Clock, Edit3, Save, X } from 'lucide-react'
+
+export default function UserProfile() {
+  const hydrated = useHydration()
+  const { user, setUser } = useAuthStore()
+  const [isEditingName, setIsEditingName] = useState(false)
+  const [newDisplayName, setNewDisplayName] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  // 초기값 설정
+  useEffect(() => {
+    if (user?.displayName) {
+      setNewDisplayName(user.displayName)
+    } else if (user?.email) {
+      setNewDisplayName(user.email.split('@')[0])
+    }
+  }, [user])
+
+  // hydration이 완료되지 않았으면 로딩 표시
+  if (!hydrated) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm border p-4 md:p-6">
+        <div className="flex items-center justify-center min-h-[200px]">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600"></div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!user) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm border p-6">
+        <p className="text-gray-600">사용자 정보를 불러올 수 없습니다.</p>
+      </div>
+    )
+  }
+
+  // 가입일과 최근 로그인 포맷팅
+  const formatDate = (timestamp: string | null) => {
+    if (!timestamp) return '정보 없음'
+    return new Date(timestamp).toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+  }
+
+  // 닉네임 변경
+  const handleUpdateDisplayName = async () => {
+    if (!auth.currentUser || !newDisplayName.trim()) return
+    
+    setIsLoading(true)
+    try {
+      await updateProfile(auth.currentUser, {
+        displayName: newDisplayName.trim()
+      })
+      // 실시간으로 사용자 상태 업데이트
+      setUser(auth.currentUser)
+      setIsEditingName(false)
+    } catch (error) {
+      console.error('닉네임 변경 오류:', error)
+      alert('닉네임 변경에 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border p-4 md:p-6">
+      <h3 className="text-lg font-semibold mb-6 flex items-center gap-2">
+        <User className="w-5 h-5 text-gray-600" />
+        사용자 정보
+      </h3>
+
+      <div className="space-y-6">
+        {/* 이메일 정보 */}
+        <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-lg">
+          <Mail className="w-5 h-5 text-gray-600" />
+          <div>
+            <p className="text-sm text-gray-600">이메일</p>
+            <p className="font-medium text-gray-900">{user.email}</p>
+          </div>
+        </div>
+
+        {/* 닉네임 */}
+        <div className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg">
+          <User className="w-5 h-5 text-gray-600 mt-1" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-gray-600">닉네임</p>
+            {isEditingName ? (
+              <div className="mt-1 space-y-2">
+                <input
+                  type="text"
+                  value={newDisplayName}
+                  onChange={(e) => setNewDisplayName(e.target.value)}
+                  className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent text-gray-900 bg-white"
+                  placeholder="닉네임 입력"
+                />
+                <div className="flex flex-col sm:flex-row gap-2">
+                  <button
+                    onClick={handleUpdateDisplayName}
+                    disabled={isLoading || !newDisplayName.trim()}
+                    className="flex items-center justify-center gap-2 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50"
+                  >
+                    <Save className="w-4 h-4" />
+                    <span className="text-sm">저장</span>
+                  </button>
+                  <button
+                    onClick={() => {
+                      setIsEditingName(false)
+                      setNewDisplayName(user.displayName || user.email?.split('@')[0] || '')
+                    }}
+                    className="flex items-center justify-center gap-2 px-3 py-2 bg-gray-300 text-gray-700 rounded-lg hover:bg-gray-400"
+                  >
+                    <X className="w-4 h-4" />
+                    <span className="text-sm">취소</span>
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 mt-1">
+                <p className="font-medium text-gray-900 truncate">
+                  {user.displayName || user.email?.split('@')[0] || '사용자'}
+                </p>
+                <button
+                  onClick={() => setIsEditingName(true)}
+                  className="p-1 text-gray-600 hover:text-green-600 flex-shrink-0"
+                  title="닉네임 수정"
+                >
+                  <Edit3 className="w-4 h-4" />
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 가입일 */}
+        <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-lg">
+          <Calendar className="w-5 h-5 text-gray-600" />
+          <div>
+            <p className="text-sm text-gray-600">가입일</p>
+            <p className="font-medium text-gray-900">
+              {formatDate(user.metadata?.creationTime || null)}
+            </p>
+          </div>
+        </div>
+
+        {/* 최근 로그인 */}
+        <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-lg">
+          <Clock className="w-5 h-5 text-gray-600" />
+          <div>
+            <p className="text-sm text-gray-600">최근 로그인</p>
+            <p className="font-medium text-gray-900">
+              {formatDate(user.metadata?.lastSignInTime || null)}
+            </p>
+          </div>
+        </div>
+
+        {/* 추가 기능 (나중에 구현) */}
+        <div className="border-t pt-6">
+          <p className="text-gray-500 text-sm">
+            비밀번호 변경과 계정 탈퇴 기능은 곧 추가될 예정입니다.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { create, StateCreator } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { User } from 'firebase/auth'
 
@@ -11,32 +11,28 @@ interface AuthState {
   logout: () => void
 }
 
+const authStore: StateCreator<AuthState> = (set) => ({
+  user: null,
+  isAuthenticated: false,
+  isLoading: true,
+  setUser: (user: User | null) => set({ 
+    user, 
+    isAuthenticated: !!user,
+    isLoading: false
+  }),
+  setLoading: (loading: boolean) => set({ isLoading: loading }),
+  logout: () => set({ 
+    user: null, 
+    isAuthenticated: false,
+    isLoading: false
+  })
+})
+
 export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
-      user: null,
-      isAuthenticated: false,
-      isLoading: true,
-      setUser: (user) => set({ 
-        user, 
-        isAuthenticated: !!user,
-        isLoading: false
-      }),
-      setLoading: (loading) => set({ isLoading: loading }),
-      logout: () => set({ 
-        user: null, 
-        isAuthenticated: false,
-        isLoading: false
-      })
+  persist(authStore, {
+    name: 'auth-storage',
+    partialize: (state) => ({ 
+      isAuthenticated: state.isAuthenticated
     }),
-    {
-      name: 'auth-storage',
-      // user 객체는 직렬화가 복잡하므로 isAuthenticated만 저장
-      partialize: (state) => ({ 
-        isAuthenticated: state.isAuthenticated
-      }),
-      // hydration 안전성을 위한 설정
-      skipHydration: true,
-    }
-  )
+  })
 )


### PR DESCRIPTION
- React Hook 규칙 위반으로 인한 렌더링 오류 해결
- UserProfile 컴포넌트 완전 재작성으로 Hook 순서 문제 해결
- 핵심 기능 유지: 이메일 표시, 닉네임 수정, 가입일/로그인 일자 표시
- 모바일 반응형 디자인 유지
- 비밀번호 변경/계정 탈퇴 기능은 향후 안정적으로 추가 예정
- AuthProvider에서 persist.rehydrate 오류 수정
- Navbar에서 사용자 정보 클릭 시 설정 페이지로 이동 기능 추가
- .gitignore에 AutoBlogPython 폴더 제외 규칙 추가

🤖 Generated with [Claude Code](https://claude.ai/code)